### PR TITLE
Optimize DSHOT timing

### DIFF
--- a/src/main/drivers/dshot_dpwm.h
+++ b/src/main/drivers/dshot_dpwm.h
@@ -30,8 +30,8 @@
 #define MOTOR_DSHOT300_HZ     MHZ_TO_HZ(22.5)
 #define MOTOR_DSHOT150_HZ     MHZ_TO_HZ(11.25)
 
-#define MOTOR_BIT_0           29
-#define MOTOR_BIT_1           57
+#define MOTOR_BIT_0           25
+#define MOTOR_BIT_1           51
 #define MOTOR_BITLENGTH       75
 #define GCR_BITLEN            60
 

--- a/src/main/drivers/dshot_dpwm.h
+++ b/src/main/drivers/dshot_dpwm.h
@@ -24,6 +24,22 @@
 
 #include "drivers/motor.h"
 
+
+#if defined(STM32F446xx)
+#define MOTOR_DSHOT600_HZ     MHZ_TO_HZ(45)
+#define MOTOR_DSHOT300_HZ     MHZ_TO_HZ(22.5)
+#define MOTOR_DSHOT150_HZ     MHZ_TO_HZ(11.25)
+
+#define MOTOR_BIT_0           29
+#define MOTOR_BIT_1           57
+#define MOTOR_BITLENGTH       75
+#define GCR_BITLEN            60
+
+#define MOTOR_PROSHOT1000_HZ         MHZ_TO_HZ(90)
+#define PROSHOT_BASE_SYMBOL          90 // 1uS
+#define PROSHOT_BIT_WIDTH            11
+#define MOTOR_NIBBLE_LENGTH_PROSHOT  360 // 4uS
+#else
 #define MOTOR_DSHOT600_HZ     MHZ_TO_HZ(12)
 #define MOTOR_DSHOT300_HZ     MHZ_TO_HZ(6)
 #define MOTOR_DSHOT150_HZ     MHZ_TO_HZ(3)
@@ -31,13 +47,8 @@
 #define MOTOR_BIT_0           7
 #define MOTOR_BIT_1           14
 #define MOTOR_BITLENGTH       20
+#define GCR_BITLEN            16
 
-#if defined(STM32F446xx)
-#define MOTOR_PROSHOT1000_HZ         MHZ_TO_HZ(90)
-#define PROSHOT_BASE_SYMBOL          90 // 1uS
-#define PROSHOT_BIT_WIDTH            11
-#define MOTOR_NIBBLE_LENGTH_PROSHOT  360 // 4uS
-#else
 #define MOTOR_PROSHOT1000_HZ         MHZ_TO_HZ(24)
 #define PROSHOT_BASE_SYMBOL          24 // 1uS
 #define PROSHOT_BIT_WIDTH            3

--- a/src/main/drivers/pwm_output_dshot_shared.c
+++ b/src/main/drivers/pwm_output_dshot_shared.c
@@ -148,7 +148,7 @@ static uint32_t decodeTelemetryPacket(uint32_t buffer[], uint32_t count)
             if (bits >= 21) {
                 break;
             }
-            len = (diff + 8) / 16;
+            len = (diff + GCR_BITLEN / 2) / GCR_BITLEN;
         } else {
             len = 21 - bits;
         }


### PR DESCRIPTION
Should fix DSHOT problems with betaflight 4.1

RADIX hex file for testing [here](https://drive.google.com/file/d/1T1wjYhmgf4aFpIcURJYtuScAhWRuHmvM/view?usp=sharing)